### PR TITLE
some work in progress suggestions

### DIFF
--- a/src/Propel/Builder/ORM/BaseActiveRecord.php
+++ b/src/Propel/Builder/ORM/BaseActiveRecord.php
@@ -67,7 +67,7 @@ class BaseActiveRecord extends ORMBuilder
             'GENERATOR_TYPE_AUTO',
             'GENERATOR_TYPE_SEQUENCE',
             'GENERATOR_TYPE_TABLE',
-            'GENERATOR_TYPE_IDENTITY', 
+            'GENERATOR_TYPE_IDENTITY',
             'GENERATOR_TYPE_NONE',
         );
 
@@ -123,7 +123,7 @@ class BaseActiveRecord extends ORMBuilder
     static protected function isToManyAssociation($associationType)
     {
         return (bool) ($associationType & ClassMetadata::TO_MANY);
-    }    
+    }
     
     protected function getAssociationDetails()
     {

--- a/src/Propel/Builder/ORM/templates/BaseActiveRecord/ActiveEntity.php.twig
+++ b/src/Propel/Builder/ORM/templates/BaseActiveRecord/ActiveEntity.php.twig
@@ -56,13 +56,104 @@
     }
 
     /**
+     * Perform custom actions before persisting a new object.
+     * Returning a non-true value will cancel persisting the object.
+     * 
+     * @return bool
+     */
+    public function preInsert()
+    {
+        return true;
+    }
+
+    /**
+     * Perform custom actions before persisting an existing.
+     * Returning a non-true value will cancel persisting the object.
+     * 
+     * @return bool
+     */
+    public function preUpdate()
+    {
+        return true;
+    }
+
+    /**
+     * Perform custom actions before persisting any object.
+     * Returning a non-true value will cancel persisting the object.
+     * 
+     * @return bool
+     */
+    public function preSave()
+    {
+        return true;
+    }
+
+    /**
      * Persist the current object and flush the entity manager
      */
     public function save()
     {
-        $em = self::getEntityManager();
-        $em->persist($this);
-        $em->flush();
+        return $this->doSave(true);
+    }
+
+    /**
+     * Persist the current object without flushing the entity manager
+     */
+    public function persist()
+    {
+        return $this->doSave(false);
+    }
+
+    /**
+     * Perform a save task, with our without flushing the entity manager.
+     */
+    protected function doSave($flush = true)
+    {
+        if ($this->isNew()) {
+            $isInsert = true;
+            $ret = $this->preInsert();
+        } else {
+            $isInsert = false;
+            $ret = $this->preUpdate();
+        }
+
+        if ($ret && $this->preSave())
+        {
+            $em = self::getEntityManager();
+            $em->persist($this);
+            
+            if ($flush) {
+                $em->flush();
+            }
+            
+            if ($isInsert) {
+                $this->postInsert();
+            } else {
+                $this->postUpdate();
+            }
+            $this->postSave();
+        }
+    }
+
+    /**
+     * Perform custom actions after persisting a new object.
+     */
+    public function postInsert()
+    {
+    }
+
+    /**
+     * Perform custom actions after persisting an existing object.
+     */
+    public function postUpdate()
+    {
+    }
+
+    /**
+     * Perform custom actions after persisting any object.
+     */
+    public function postSave()
+    {
     }
 
     /**

--- a/tests/Propel/Tests/Builder/ORM/BaseActiveRecord/GetterSetterTest.php
+++ b/tests/Propel/Tests/Builder/ORM/BaseActiveRecord/GetterSetterTest.php
@@ -11,7 +11,7 @@ class GetterSetterTest extends \PHPUnit_Framework_TestCase
     static public function setUpBeforeClass()
     {
         $metadata = new ClassMetadataInfo('Propel\\Tests\\Builder\\ORM\\BaseActiveRecord\\GetterSetterEntity');
-        $metadata->setTableName('author');
+        $metadata->setPrimaryTable(array('name' => 'author'));
         $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_AUTO);
         $metadata->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
         $metadata->mapField(array('fieldName' => 'firstName', 'type' => 'string'));

--- a/tests/Propel/Tests/Builder/ORM/BaseActiveRecordTest.php
+++ b/tests/Propel/Tests/Builder/ORM/BaseActiveRecordTest.php
@@ -15,7 +15,7 @@ class BaseActiveRecordTest extends TestCase
     static public function setUpBeforeClass()
     {
         $metadata = new ClassMetadataInfo('Propel\\Tests\\Builder\\ORM\\Author');
-        $metadata->setTableName('author');
+        $metadata->setPrimaryTable(array('name' => 'author'));
         $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_AUTO);
         $metadata->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
         $metadata->mapField(array('fieldName' => 'firstName', 'type' => 'string', 'nullable' => true));
@@ -42,6 +42,15 @@ class BaseActiveRecordTest extends TestCase
         $this->assertEquals(UnitOfWork::STATE_MANAGED, $this->entityManager->getUnitOfWork()->getEntityState($author));
     }
 
+    public function testPersist()
+    {
+        $author = new Base\Author();
+        $this->assertEquals(UnitOfWork::STATE_NEW, $this->entityManager->getUnitOfWork()->getEntityState($author));
+        $author->persist();
+        $this->assertNull($author->getId());
+        $this->assertEquals(UnitOfWork::STATE_MANAGED, $this->entityManager->getUnitOfWork()->getEntityState($author));
+    }
+
     public function testIsNew()
     {
         $author = new Base\Author();
@@ -57,5 +66,4 @@ class BaseActiveRecordTest extends TestCase
         $author->save();
         $this->assertFalse($author->isModified());
     }
-
 }


### PR DESCRIPTION
added persist() method to BaseActiveRecord, allowing to save() without flushing the EntityManager (for batch persisting).
added pre_() and post_() hooks in propel1 fashion

I looked into the Doctrine2 docs and found that the existing Doctrine2 events for prePersist etc. lack some functionality, e.g. directly differentiating between insert and update. They also have to be declared as lifecycle-callbacks in the schema if to be used directly.

My long-term suggestion is modifying the schema to always include the lifecycle-callbacks automatically and explicitly creating the hook methods based on the events, to stay compatible to D2.
